### PR TITLE
Update KingSolution.s.sol without the typo

### DIFF
--- a/script/KingSolution.s.sol
+++ b/script/KingSolution.s.sol
@@ -7,7 +7,7 @@ import "forge-std/console.sol";
 
 contract TheLastKing {
     constructor(King _kingInstacne) payable {
-        (bool result,) = address(_kingInstacne).call{value: _kingInstacne.prize()}("");
+        (bool result,) = address(_kingInstance).call{value: _kingInstacne.prize()}("");
         require(result);
     }
 }


### PR DESCRIPTION
There is a typo in the solutions script for the King level. It should read instance. 