### PR TITLE
Fix "src/GatekeeperOne.sol" not found:

### DIFF
--- a/script/GateKeeperOneSolution.s.sol
+++ b/script/GateKeeperOneSolution.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol";
-import {GatekeeperOne} from "../src/GatekeeperOne.sol";
+import {GatekeeperOne} from "../src/GateKeeperOne.sol";
  
 contract GatekeeperOneSolution is Script {
 


### PR DESCRIPTION
Error Description:

After Running
```
forge build
```
The following error Message appears:

```
Error: Compiler run failed:
Error (6275): Source "src/GatekeeperOne.sol" not found: File not found. 
```

This pull request fixes the issue by changing the import